### PR TITLE
Add span around inline scratchblocks to include css ++

### DIFF
--- a/src/components/LessonPage/Content.scss
+++ b/src/components/LessonPage/Content.scss
@@ -54,6 +54,14 @@ code.b {
   border: 0;
 }
 
+.inlineScratchblocks {
+  display: inline-block;
+  transform: scale(0.8); // Using 0.8 instead of the standard 0.675
+  //transform-origin: 0 0;
+  // hack until https://github.com/scratchblocks/scratchblocks/issues/296 is solved:
+  transform-origin: 50% 280%;
+}
+
 // code blocks
 pre > code {
   // override hljs background
@@ -180,16 +188,16 @@ section.challenge {
 // manual colors for scratch code
 // example: Press `motion`{.blockmotion} ...
 code {
-  &.blockmotion { background-color: #4C97FF; }
-  &.blocklooks { background-color: #9966FF; }
-  &.blocksound { background-color: #CF63CF; }
-  &.blockpen { background-color: #0FBD8C; }
-  &.blockdata { background-color: #FF8C1A; }
-  &.blockevents { background-color: #FFBF00; }
-  &.blockcontrol { background-color: #FFAB19; }
-  &.blocksensing { background-color: #5CB1D6; }
-  &.blockoperators { background-color: #59C059; }
-  &.blockmoreblocks { background-color: #FF6680; }
+  &.blockmotion { background-color: #4c97ff; }
+  &.blocklooks { background-color: #96f; }
+  &.blocksound { background-color: #cf63cf; }
+  &.blockpen { background-color: #0fbd8c; }
+  &.blockdata { background-color: #ff8c1a; }
+  &.blockevents { background-color: #ffbf00; }
+  &.blockcontrol { background-color: #ffab19; }
+  &.blocksensing { background-color: #5cb1d6; }
+  &.blockoperators { background-color: #59c059; }
+  &.blockmoreblocks { background-color: #ff6680; }
 
   &.blockmotion,
   &.blocklooks,

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -37,16 +37,16 @@ $color-level3: #d63838;
 $color-level4: $color-gray-dark;
 
 //	Scratch block colors
-$color-scratchblock-motion:     #4C97FF;
-$color-scratchblock-looks:      #9966FF;
-$color-scratchblock-sound:      #CF63CF;
-$color-scratchblock-pen:        #0FBD8C;
-$color-scratchblock-data:       #FF8C1A;
-$color-scratchblock-events:     #FFBF00;
-$color-scratchblock-control:    #FFAB19;
-$color-scratchblock-sensing:    #5CB1D6;
-$color-scratchblock-operators:  #59C059;
-$color-scratchblock-moreblocks: #FF6680;
+$color-scratchblock-motion:     #4c97ff;
+$color-scratchblock-looks:      #96f;
+$color-scratchblock-sound:      #cf63cf;
+$color-scratchblock-pen:        #0fbd8c;
+$color-scratchblock-data:       #ff8c1a;
+$color-scratchblock-events:     #ffbf00;
+$color-scratchblock-control:    #ffab19;
+$color-scratchblock-sensing:    #5cb1d6;
+$color-scratchblock-operators:  #59c059;
+$color-scratchblock-moreblocks: #ff6680;
 
 // Fonts
 $font-size-xs-pct: 106.25%; // 17px if base font is 16px

--- a/src/utils/processContent.js
+++ b/src/utils/processContent.js
@@ -145,7 +145,11 @@ const renderScratchBlocks = (content, styles) => {
         let doc = scratchblocks.parse(code, r.options);
         let docView = scratchblocks.newView(doc, {style: 'scratch3'});
         let svg = docView.render();
-        returnContent = returnContent.replace(block, svg.outerHTML);
+        let html = svg.outerHTML;
+        if (r.options.inline) {
+          html = `<span class="${styles.inlineScratchblocks}">${html}</span>`;
+        }
+        returnContent = returnContent.replace(block, html);
       });
     }
   });


### PR DESCRIPTION
Add span around inline scratchblocks to include css, and lowercase css colorcodes for linter.

Fint om du tester det littegrann for å se at jeg ikke har oversett noe... (gjerne i de browserne du har)...